### PR TITLE
hotfix: 🚑 indexの`Flow`のスタイルが崩れるバグを修正他

### DIFF
--- a/src/components/index/Flow.tsx
+++ b/src/components/index/Flow.tsx
@@ -26,7 +26,7 @@ const FlowBox: FC<{ className: string; children: ReactNode; type: "timetable" | 
   children,
   type,
 }) => (
-  <div className="relative">
+  <div className="relative w-full">
     <button
       type="button"
       onClick={() => {
@@ -34,7 +34,7 @@ const FlowBox: FC<{ className: string; children: ReactNode; type: "timetable" | 
       }}
     >
       <div
-        className={`h-[146px] rounded-lg ${className} transition hover:-translate-y-1 hover:-translate-x-1 active:translate-y-3 active:translate-x-3`}
+        className={`h-[146px] w-full rounded-lg ${className} transition hover:-translate-y-1 hover:-translate-x-1 active:translate-y-3 active:translate-x-3`}
       >
         {children}
       </div>

--- a/src/static/timetableData.ts
+++ b/src/static/timetableData.ts
@@ -252,7 +252,7 @@ const timetableData: Data = {
       },
       {
         eventTitle: "ふかずめ",
-        description: "Let me make some noice.",
+        description: "Let me make some noise.",
         start: "13:50",
         end: "14:05",
         time: 1.5,


### PR DESCRIPTION
## Supported

- timetableのタイポミス修正
- indexの`Flow`のスタイルのバグ修正