### PR TITLE
🍱 (Update): timetable data

### DIFF
--- a/src/static/timetableData.ts
+++ b/src/static/timetableData.ts
@@ -69,7 +69,7 @@ const timetableData: Data = {
       ],
       [
         {
-          eventTitle: "ガサ入れプランクトン",
+          eventTitle: "がさいれぷらんくとん",
           description: "あなたの心をガサ入れ！YOASOBI等のバンド演奏！",
           start: "11:00",
           end: "11:20",
@@ -211,7 +211,7 @@ const timetableData: Data = {
       ],
       [
         {
-          eventTitle: "ガサ入れプランクトン",
+          eventTitle: "がさいれぷらんくとん",
           description: "あなたの心をガサ入れ！YOASOBI等のバンド演奏！",
           start: "12:30",
           end: "12:50",


### PR DESCRIPTION
「ガサ入れプランクトン」の表記を全ひらがなになおしてほしいとのことだったので修正